### PR TITLE
Removed 'normalize_spaces', redundant operation handled by argparse.ArgumentDefaultsHelpFormatter.

### DIFF
--- a/mando/tests/test_utils.py
+++ b/mando/tests/test_utils.py
@@ -85,8 +85,7 @@ for a in (a_1, a_2, a_3):
     dict(doc='''
          Lemme see.
 
-         :param long-story: A long storey belive me: when all started, Adam and
-             Bob were just two little farmers.
+         :param long-story: A long storey belive me: when all started, Adam and Bob were just two little farmers.
          ''', params={'long_story': (['long-story'], {'help': 'A long storey '\
                                      'belive me: when all started, Adam and '\
                                      'Bob were just two little farmers.'})}),

--- a/mando/utils.py
+++ b/mando/utils.py
@@ -14,11 +14,6 @@ ARG_TYPE_MAP = {
 }
 
 
-def normalize_spaces(string):
-    '''Convert whitespace to spaces.'''
-    return re.sub(r'[\r\t\n ]+', ' ', string)
-
-
 def purify_doc(string):
     '''Remove Sphinx's :param: lines from the docstring.'''
     return PARAM_RE.sub('', string).rstrip()
@@ -53,7 +48,7 @@ def find_param_docs(docstring):
         paramdocs[name] = (opts, {
             'metavar': meta or None,
             'type': ARG_TYPE_MAP.get(meta.strip('<>')),
-            'help': normalize_spaces(value).rstrip(),
+            'help': value.rstrip(),
         })
     return paramdocs
 


### PR DESCRIPTION
Leaving the text untouched allows the use of other argparse formatter classes.  As discussed in https://github.com/rubik/mando/issues/13 with this change can use the argparse RawTextHelpFormatter formatter class like:

```
from argparse import RawTextHelpFormatter
@mando.command(formatter_class=RawTextHelpFormatter)
def myfunction():
    '''This
       will
       format
       exactly
       the
       way
       that
       I
       want.
    '''
```
