### PR TITLE
add docs and examples to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.rst
+recursive-include docs *
+recursive-include examples *.py


### PR DESCRIPTION
When packaging mando from source, it's great if the documentation is
included so that user's have the option of installing it to their
system.