### PR TITLE
Support for mando, ReST, Numpy, and Google docstrings

### DIFF
--- a/mando/tests/capture.py
+++ b/mando/tests/capture.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Capture function
+----------------------------------
+
+"""
+
+from contextlib import contextmanager
+import sys
+
+try:
+    from cStringIO import StringIO
+except:
+    from io import StringIO
+
+
+@contextmanager
+def capture_sys_output():
+    capture_out, capture_err = StringIO(), StringIO()
+    current_out, current_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = capture_out, capture_err
+        yield capture_out, capture_err
+    finally:
+        sys.stdout, sys.stderr = current_out, current_err
+

--- a/mando/tests/run.py
+++ b/mando/tests/run.py
@@ -1,9 +1,12 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 if __name__ == '__main__':
     import unittest
     from mando.tests.test_core import *
     from mando.tests.test_utils import *
     from mando.tests.test_unicode_docstring_on_py2 import *
+
+    from mando.tests.test_google import *
+    from mando.tests.test_numpy import *
 
     unittest.main()

--- a/mando/tests/test_google.py
+++ b/mando/tests/test_google.py
@@ -1,0 +1,63 @@
+import unittest
+
+from paramunittest import parametrized
+from mando import Program
+
+from . import capture
+
+program = Program('example.py', '1.0.10')
+
+@program.command(doctype='google')
+def simple_google_docstring(arg1, arg2="string"):
+    '''One line summary.
+
+    Extended description.
+
+    Args:
+      arg1(int): Description of `arg1`
+      arg2(str): Description of `arg2`
+    Returns:
+      str: Description of return value.
+    '''
+    return int(arg1) * arg2
+
+@parametrized(
+    ('simple_google_docstring 2 --arg2=test', 'testtest'),
+    )
+class TestGenericCommands(unittest.TestCase):
+
+    def setParameters(self, args, result):
+        self.args = args.split()
+        self.result = result
+
+    def testExecute(self):
+        self.assertEqual(self.result, program.execute(self.args))
+        self.assertEqual(program.parse(self.args)[0].__name__,
+                         program.current_command)
+
+
+@parametrized(
+    ('simple_google_docstring --help 2 --arg2=test', '''usage: example.py simple_google_docstring [-h] [--arg2 ARG2] arg1
+
+Extended description. Description of return value.
+
+positional arguments:
+  arg1         Description of `arg1`
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --arg2 ARG2  Description of `arg2`
+'''
+    ),
+)
+class TestGoogleDocstringHelp(unittest.TestCase):
+
+    def setParameters(self, args, result):
+        self.args = args.split()
+        self.result = result
+
+    def testExecute(self):
+        with self.assertRaises(SystemExit) as cm:
+            with capture.capture_sys_output() as (stdout, stderr):
+                program.execute(self.args)
+        self.assertEqual(self.result, stdout.getvalue())

--- a/mando/tests/test_numpy.py
+++ b/mando/tests/test_numpy.py
@@ -1,0 +1,68 @@
+import unittest
+
+from paramunittest import parametrized
+from mando import Program
+
+from . import capture
+
+program = Program('example.py', '1.0.10')
+
+@program.command(doctype='numpy')
+def simple_numpy_docstring(arg1, arg2="string"):
+    '''One line summary.
+
+    Extended description.
+
+    Parameters
+    ----------
+    arg1 : int
+        Description of `arg1`
+    arg2 : str
+        Description of `arg2`
+    Returns
+    -------
+    str
+        Description of return value.
+    '''
+    return int(arg1) * arg2
+
+@parametrized(
+    ('simple_numpy_docstring 2 --arg2=test', 'testtest'),
+    )
+class TestGenericCommands(unittest.TestCase):
+
+    def setParameters(self, args, result):
+        self.args = args.split()
+        self.result = result
+
+    def testExecute(self):
+        self.assertEqual(self.result, program.execute(self.args))
+        self.assertEqual(program.parse(self.args)[0].__name__,
+                         program.current_command)
+
+
+@parametrized(
+    ('simple_numpy_docstring --help 2 --arg2=test', '''usage: example.py simple_numpy_docstring [-h] [--arg2 ARG2] arg1
+
+Extended description. Description of return value.
+
+positional arguments:
+  arg1         Description of `arg1`
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --arg2 ARG2  Description of `arg2`
+'''
+    ),
+)
+class TestNumpyDocstringHelp(unittest.TestCase):
+
+    def setParameters(self, args, result):
+        self.args = args.split()
+        self.result = result
+
+    def testExecute(self):
+        with self.assertRaises(SystemExit) as cm:
+            with capture.capture_sys_output() as (stdout, stderr):
+                program.execute(self.args)
+        self.assertEqual(self.result, stdout.getvalue())

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ else:
     version = mando.__version__
     deps = []
 
+deps.append('sphinx')
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as fobj:
     readme = fobj.read()


### PR DESCRIPTION
Support for Numpy and Google formatted docstrings by conversion to ReST using sphinx.ext.napoleon.  Trim out unused field lists from ReST to make mando formatted docstring.