### PR TITLE
This change to SPHINX_RE will capture the entire indented text

### DIFF
--- a/mando/tests/test_google.py
+++ b/mando/tests/test_google.py
@@ -39,7 +39,7 @@ class TestGenericCommands(unittest.TestCase):
 @parametrized(
     ('simple_google_docstring --help 2 --arg2=test', '''usage: example.py simple_google_docstring [-h] [--arg2 ARG2] arg1
 
-Extended description. Description of return value.
+Extended description.
 
 positional arguments:
   arg1         Description of `arg1`

--- a/mando/tests/test_numpy.py
+++ b/mando/tests/test_numpy.py
@@ -44,7 +44,7 @@ class TestGenericCommands(unittest.TestCase):
 @parametrized(
     ('simple_numpy_docstring --help 2 --arg2=test', '''usage: example.py simple_numpy_docstring [-h] [--arg2 ARG2] arg1
 
-Extended description. Description of return value.
+Extended description.
 
 positional arguments:
   arg1         Description of `arg1`

--- a/mando/utils.py
+++ b/mando/utils.py
@@ -6,11 +6,14 @@ SPHINX_RE = re.compile(
     r' ?(?P<var1>[-\w_]+,?)?'
     r' ?(?P<var2>[-<>\w_]+)?'
     r' ?(?P<var3>[<>\w_]+)?:'
-    r'(?P<help>[^\n]*\n(\1[ \t]+[^\n]*\n)*)',
+    r'(?P<help>[^\n]*\n((\1[ \t]+[^\n]*\n)|\n)*)',
     re.MULTILINE)
-ARG_RE = re.compile(r'-(?P<long>-)?(?P<key>(?(long)[^ =,]+|.))[ =]?'
-                    '(?P<meta>[^ ,]+)?')
-POS_RE = re.compile(r'(?P<meta>[^ ,]+)?')
+ARG_RE = re.compile(
+    r'-(?P<long>-)?'
+    r'(?P<key>(?(long)[^ =,]+|.))[ =]?'
+    r'(?P<meta>[^ ,]+)?')
+POS_RE = re.compile(
+    r'(?P<meta>[^ ,]+)?')
 ARG_TYPE_MAP = {
     'n': int, 'num': int, 'number': int,
     'i': int, 'int': int, 'integer': int,


### PR DESCRIPTION
The previous SPHINX_RE thought that a blank line reset the indent.  This change makes the re ignore blank lines.