### PR TITLE
__call__ should return exit code of function just as execute does

### DIFF
--- a/mando/core.py
+++ b/mando/core.py
@@ -174,7 +174,7 @@ class Program(object):
 
     def __call__(self):  # pragma: no cover
         '''Parse ``sys.argv`` and execute the resulting command.'''
-        self.execute(sys.argv[1:])
+        return self.execute(sys.argv[1:])
 
 
 def merge(arg, default, override, args, kwargs):


### PR DESCRIPTION
Doing
```python
Script = mando.core.Program()
# ...
if __name__ == '__main__':
    sys.exit(Script.execute(sys.argv[1:]))
```
returns the return code of the subcommand function as exit code to the OS, while just calling the `Program` instance does not:
```python
Script = mando.core.Program()
# ...
if __name__ == '__main__':
    sys.exit(Script())
```
Maybe that should be consistent here?
