### PR TITLE
BUG: This change allows the help message to be displayed on ASCII terminals.

### DIFF
--- a/mando/rst_text_formatter.py
+++ b/mando/rst_text_formatter.py
@@ -19,7 +19,14 @@ class RSTHelpFormatter(argparse.RawTextHelpFormatter):
     """
     """
     def format_help(self):
-        return rst2ansi(b(super(RSTHelpFormatter, self).format_help())) + '\n'
+        ret = rst2ansi(b(super(RSTHelpFormatter, self).format_help())
+                       + '\n')
+        return ret.encode(sys.stdout.encoding,
+                          'replace').decode(sys.stdout.encoding)
 
     def format_usage(self):
-        return rst2ansi(b(super(RSTHelpFormatter, self).format_usage())) + '\n'
+        ret = rst2ansi(b(super(RSTHelpFormatter, self).format_usage())
+                       + '\n')
+        return ret.encode(sys.stdout.encoding,
+                          'replace').decode(sys.stdout.encoding)
+


### PR DESCRIPTION
Figured out that mando wouldn't display 'rst2ansi' formatted tables on a ASCII terminal, only UTF-8.  This change converts to the terminal encoding.  Don't like the encode(...).decode(...) part, but I couldn't figure out a more elegant way.  On UTF-8 terminals it would be a null operation (I think).