### PR TITLE
BUG: Fixed unicode issue that prevented RST from working on Python 3+.

### DIFF
--- a/mando/rst_text_formatter.py
+++ b/mando/rst_text_formatter.py
@@ -20,13 +20,13 @@ class RSTHelpFormatter(argparse.RawTextHelpFormatter):
     """
     def format_help(self):
         ret = rst2ansi(b(super(RSTHelpFormatter, self).format_help())
-                       + '\n')
+                       + b('\n'))
         return ret.encode(sys.stdout.encoding,
                           'replace').decode(sys.stdout.encoding)
 
     def format_usage(self):
         ret = rst2ansi(b(super(RSTHelpFormatter, self).format_usage())
-                       + '\n')
+                       + b('\n'))
         return ret.encode(sys.stdout.encoding,
                           'replace').decode(sys.stdout.encoding)
 


### PR DESCRIPTION
I forgot a conversion of "\n" to bytes on Python 3+.