### PR TITLE
Add support for Python 3.10

### DIFF
--- a/mando/tests/test_google.py
+++ b/mando/tests/test_google.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from mando import Program
 
@@ -32,7 +33,9 @@ def test_generic_command(args, result):
     assert result == program.execute(args)
     assert program.parse(args)[0].__name__ == program._current_command
 
-
+ending = 'al arguments'
+if sys.version_info[:2] >= (3, 10):
+    ending = 's'
 GOOGLE_DOCSTRING_HELP_CASES = [
     ('simple_google_docstring --help 2 --arg2=test', '''usage: example.py simple_google_docstring [-h] [--arg2 ARG2] arg1
 
@@ -41,10 +44,10 @@ Extended description.
 positional arguments:
   arg1         Description of `arg1`
 
-optional arguments:
+option%s:
   -h, --help   show this help message and exit
   --arg2 ARG2  Description of `arg2`
-'''),
+''' % ending),
 ]
 
 

--- a/mando/tests/test_numpy.py
+++ b/mando/tests/test_numpy.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from mando import Program
 
@@ -37,7 +38,9 @@ def test_generic_command(args, result):
     assert result == program.execute(args)
     assert program.parse(args)[0].__name__ == program._current_command
 
-
+ending = 'al arguments'
+if sys.version_info[:2] >= (3, 10):
+    ending = 's'
 NUMPY_DOCSTRING_HELP_CASES = [
     ('simple_numpy_docstring --help 2 --arg2=test', '''usage: example.py simple_numpy_docstring [-h] [--arg2 ARG2] arg1
 
@@ -46,10 +49,10 @@ Extended description.
 positional arguments:
   arg1         Description of `arg1`
 
-optional arguments:
+option%s:
   -h, --help   show this help message and exit
   --arg2 ARG2  Description of `arg2`
-'''),
+''' % ending),
 ]
 
 


### PR DESCRIPTION
Python 3.10 changed how optional arguments are presented in help output,
by switching to using the string 'optios'. Support this change in the
two parameterized test cases that require it by checking
sys.version_info